### PR TITLE
Fix pts conversions.

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecExynos.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecExynos.cpp
@@ -6,6 +6,7 @@
 #include <dirent.h>
 #include <sys/ioctl.h>
 #include <fstream>
+#include <cmath>
 
 namespace Exynos {
 
@@ -161,7 +162,9 @@ bool CDVDVideoCodecExynos::SendBuffer(int bufferIndex, uint8_t *demuxer_content,
   fast_memcpy((uint8_t *)m_v4l2MFCOutputBuffers[bufferIndex].cPlane[0], demuxer_content, demuxer_bytes);
   m_v4l2MFCOutputBuffers[bufferIndex].iBytesUsed[0] = demuxer_bytes;
 
-  if (!m_v4l2MFCOutputBuffers.QueueBuffer(bufferIndex, {long(pts), long((pts - long(pts)) * 1000)})) {
+  double fractpart, intpart;
+  fractpart = modf(pts / 1000000.0, &intpart);
+  if (!m_v4l2MFCOutputBuffers.QueueBuffer(bufferIndex, {long(intpart), long(fractpart * 1000000)})) {
     CLog::Log(LOGERROR, "%s::%s - MFC OUTPUT Failed to queue buffer with index %d, errno %d", CLASSNAME, __func__, bufferIndex, errno);
     return false;
   }

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecExynos4.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecExynos4.cpp
@@ -417,7 +417,7 @@ void CDVDVideoCodecExynos4::MFCtoFIMCLoop() {
           CLog::Log(LOGERROR, "%s::%s - FIMC OUTPUT Failed to queue buffer with index %d, errno %d", CLASSNAME, __func__, int(index), errno);
         } else {
           std::unique_lock<std::mutex> lock(m_mutex);
-          m_pts[m_ptsWriteIndex] = (ptsTime.tv_sec + double(ptsTime.tv_usec)/1000);
+          m_pts[m_ptsWriteIndex] = double(ptsTime.tv_sec)*1000000.0 + double(ptsTime.tv_usec);
           m_ptsWriteIndex = (m_ptsWriteIndex + 1) % FIMC_CAPTURE_BUFFERS_CNT;
         }
       }

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecExynos5.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecExynos5.h
@@ -52,7 +52,6 @@ private:
 
   V4L2Buffer m_v4l2OutputBuffer;
   int m_MFCDequeuedBufferNumber;
-  bool m_dataRequested;
   
   // Order number of previous frame
   uint32_t m_sequence;


### PR DESCRIPTION
There are two changes in this pull request:
1) pts is treated as microseconds. This fixes playback after 35 minutes.
2) I've looked how hibrys codec transfers frames to libhibris and implemented the same scheme. Now I don't wait untill MFC queue is full and return frames when they are ready. But I still maintain MFC queue full if possible. This partially fixes kludge for interlaced video.

There is still problem with 1080i kludge: sometimes MFC locks up and does not return any frames. So my kludge does not detect the problem. I'll fix it in separate commit.
