### PR TITLE
bugfix: test for m_codec==NULL

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecHybris.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecHybris.cpp
@@ -182,6 +182,7 @@ void CDVDVideoCodecHybris::Dispose() {
   while(!m_dts.empty())
     m_dts.pop();
 
+  if(!m_codec)return;
   media_codec_stop(m_codec);
   media_codec_release(m_codec);
   media_codec_delegate_destroy(m_codec);


### PR DESCRIPTION
If m_bitstream->Open fails, Open fails without m_codec and m_format being set. As a result the lines below the test will make xbmc core dump.
